### PR TITLE
Read radeon-profile-daemon-server socket from /run/radeon-profile-dae…

### DIFF
--- a/radeon-profile/daemonComm.cpp
+++ b/radeon-profile/daemonComm.cpp
@@ -34,7 +34,7 @@ void DaemonComm::sendConnectionConfirmation() {
 void DaemonComm::connectToDaemon() {
     qDebug() << "Connecting to daemon...";
     signalSender->abort();
-    signalSender->connectToServer("/run/radeon-profile-daemon-server");
+    signalSender->connectToServer("/run/radeon-profile-daemon/radeon-profile-daemon-server");
 }
 
 void DaemonComm::disconnectDaemon() {


### PR DESCRIPTION
Change socket file read location in coherence with where it is now properly set in Radeon Profile Daemon

Now that the UNIX socket in radeon-profile-daemon has been moved to a subdirectory in order to no longer make it world writeable, we need to update the socket path.

Depends on marazmista/radeon-profile-daemon#23.

Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>
[rewrote original commit message as it's no longer Gentoo specific]
Signed-off-by: Stijn Tintel <stijn@linux-ipv6.be>